### PR TITLE
Allow to override routingKeys in the publish() method

### DIFF
--- a/src/AmqpBundle/Amqp/Producer.php
+++ b/src/AmqpBundle/Amqp/Producer.php
@@ -30,11 +30,12 @@ class Producer extends AbstractAmqp
     }
 
     /**
-     * @param string $message    The message to publish.
-     * @param int    $flags      One or more of AMQP_MANDATORY and AMQP_IMMEDIATE.
-     * @param array  $attributes One of content_type, content_encoding,
-     *                           message_id, user_id, app_id, delivery_mode, priority,
-     *                           timestamp, expiration, type or reply_to.
+     * @param string $message     The message to publish.
+     * @param int    $flags       One or more of AMQP_MANDATORY and AMQP_IMMEDIATE.
+     * @param array  $attributes  One of content_type, content_encoding,
+     *                            message_id, user_id, app_id, delivery_mode, priority,
+     *                            timestamp, expiration, type or reply_to.
+     * @param array  $routingKeys If set, overrides the Producer 'routing_keys' for this message
      *
      * @return boolean          TRUE on success or FALSE on failure.
      *
@@ -42,16 +43,20 @@ class Producer extends AbstractAmqp
      * @throws \AMQPChannelException If the channel is not open.
      * @throws \AMQPConnectionException If the connection to the broker was lost.
      */
-    public function publishMessage($message, $flags = AMQP_NOPARAM, array $attributes = [])
+    public function publishMessage($message, $flags = AMQP_NOPARAM, array $attributes = [], array $routingKeys = [])
     {
         // Merge attributes
         $attributes = empty($attributes) ? $this->exchangeOptions['publish_attributes'] :
                       (empty($this->exchangeOptions['publish_attributes']) ? $attributes :
                       array_merge($this->exchangeOptions['publish_attributes'], $attributes));
 
+        if (empty($routingKeys)) {
+            $routingKeys = $this->exchangeOptions['routing_keys'];
+        }
+
         // Publish the message for each routing keys
         $success = true;
-        foreach ($this->exchangeOptions['routing_keys'] as $routingKey) {
+        foreach ($routingKeys as $routingKey) {
             $success &= $this->call($this->exchange, 'publish', [$message, $routingKey, $flags, $attributes]);
         }
 

--- a/src/AmqpBundle/Tests/Units/Amqp/Producer.php
+++ b/src/AmqpBundle/Tests/Units/Amqp/Producer.php
@@ -125,6 +125,32 @@ class Producer extends atoum
                     ->isTrue();
     }
 
+    public function testSendMessageWithOverridedRoutingKey()
+    {
+        $msgList = [];
+
+        // To verify merged attributs
+        $this
+            ->if($msgList = [])
+            ->and($exchange = $this->getExchange($msgList))
+            ->and($exchangeOptions = [
+                'routing_keys' => ['routing_test', 'routing_test2']
+            ])
+
+            ->and($producer = new Base($exchange, $exchangeOptions))
+            ->boolean($producer->publishMessage('message1'))
+            ->isTrue()
+            ->boolean($producer->publishMessage('message2', AMQP_IMMEDIATE, [], ['routing_override1', 'routing_override2']))
+            ->isTrue()
+            ->array($msgList)
+            ->isEqualTo([
+                ['message1', 'routing_test', AMQP_NOPARAM, []],
+                ['message1', 'routing_test2', AMQP_NOPARAM, []],
+                ['message2', 'routing_override1', AMQP_IMMEDIATE, []],
+                ['message2', 'routing_override2', AMQP_IMMEDIATE, []],
+            ]);
+    }
+
     protected function getExchange(&$msgList = [])
     {
         $this->mockGenerator->orphanize('__construct');


### PR DESCRIPTION
This is useful for publishing a message with a dynamically computed routingKey.