### PR TITLE
[RFR] Fix publishing message when routing keys is an empty array

### DIFF
--- a/src/AmqpBundle/Amqp/Producer.php
+++ b/src/AmqpBundle/Amqp/Producer.php
@@ -50,8 +50,9 @@ class Producer extends AbstractAmqp
                       (empty($this->exchangeOptions['publish_attributes']) ? $attributes :
                       array_merge($this->exchangeOptions['publish_attributes'], $attributes));
 
-        if (empty($routingKeys)) {
-            $routingKeys = $this->exchangeOptions['routing_keys'];
+        $routingKeys = !empty($routingKeys) ? $routingKeys : $this->exchangeOptions['routing_keys'];
+        if (!$routingKeys) {
+            return $this->call($this->exchange, 'publish', [$message, null, $flags, $attributes]);
         }
 
         // Publish the message for each routing keys

--- a/src/AmqpBundle/Tests/Units/Amqp/Producer.php
+++ b/src/AmqpBundle/Tests/Units/Amqp/Producer.php
@@ -151,6 +151,29 @@ class Producer extends atoum
             ]);
     }
 
+    public function testSendMessagesWithoutRoutingKey()
+    {
+        $msgList = [];
+
+        $this
+            ->if($msgList = [])
+            ->and($exchange = $this->getExchange($msgList))
+            ->and($exchangeOptions = [
+                'publish_attributes' => ['attr_test' => 'value'],
+                'routing_keys' => []
+            ])
+            ->and($producer = new Base($exchange, $exchangeOptions))
+                ->boolean($producer->publishMessage('message1'))
+                    ->isTrue()
+                ->boolean($producer->publishMessage('message2'))
+                    ->isTrue()
+                ->array($msgList)
+                    ->isEqualTo([
+                        ['message1', null, AMQP_NOPARAM, $exchangeOptions['publish_attributes']],
+                        ['message2', null, AMQP_NOPARAM, $exchangeOptions['publish_attributes']],
+            ]);
+    }
+
     protected function getExchange(&$msgList = [])
     {
         $this->mockGenerator->orphanize('__construct');


### PR DESCRIPTION
Hi,

When no routing key is defined in configuration, message are not published. It's not mandatory to define routing when creating exchange/queue in rabbitmq.

Thierry



