### PR TITLE
[RFR] queue_options is not mandatory

### DIFF
--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -68,6 +68,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('class')->defaultValue('%m6_web_amqp.producer.class%')->end()
                             ->scalarNode('connection')->defaultValue('default')->end()
                             ->arrayNode('queue_options')
+                                ->addDefaultsIfNotSet()
                                 ->children()
                                     // base info
                                     ->scalarNode('name')->end()


### PR DESCRIPTION
v1.6.0 breaks compatibility with 1.5x : queue option shouldn't be mandatory.