### PR TITLE
Fix exchange arguments

### DIFF
--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -94,6 +94,7 @@ class Configuration implements ConfigurationInterface
                                     ->arrayNode('arguments')
                                         ->prototype('scalar')->end()
                                         ->defaultValue(array())
+                                        ->normalizeKeys(false)
                                     ->end()
 
                                     // binding

--- a/src/AmqpBundle/Factory/ProducerFactory.php
+++ b/src/AmqpBundle/Factory/ProducerFactory.php
@@ -94,6 +94,7 @@ class ProducerFactory
         $exchange = new $this->exchangeClass($channel);
         $exchange->setName($exchangeOptions['name']);
         $exchange->setType($exchangeOptions['type']);
+        $exchange->setArguments($exchangeOptions['arguments']);
         $exchange->setFlags(
             ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
             ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |

--- a/src/AmqpBundle/Tests/Units/Factory/ProducerFactory.php
+++ b/src/AmqpBundle/Tests/Units/Factory/ProducerFactory.php
@@ -75,7 +75,8 @@ class ProducerFactory extends atoum
                 'passive' => false,
                 'durable' => true,
                 'auto_delete' => false,
-                'routing_keys' => ['key']
+                'routing_keys' => ['key'],
+                'arguments' => ['alternate-exchange' => 'my-ae'],
             ])
             ->and($queueOptions = [
                 'name' => 'myqueue',


### PR DESCRIPTION
  * Pass configured arguments to AMQPExchange, before exchange declaration.
  * Disable key normalization for exchange arguments config (dashes were converted to underscore)