### PR TITLE
WIP: consumer command

### DIFF
--- a/src/AmqpBundle/Amqp/CallbackInterface.php
+++ b/src/AmqpBundle/Amqp/CallbackInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace M6Web\Bundle\AmqpBundle\Amqp;
+
+/**
+ * Callback to be called in Consumer::consume() on message receive
+ *
+ * @see Consumer
+ */
+interface CallbackInterface
+{
+    /**
+     * @param \AMQPEnvelope $message
+     *
+     * @return bool whether message was acked
+     */
+    public function consume(\AMQPEnvelope $message);
+}

--- a/src/AmqpBundle/Command/AMQPConsumerCommand.php
+++ b/src/AmqpBundle/Command/AMQPConsumerCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace M6Web\Bundle\AmqpBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use M6Web\Bundle\AmqpBundle\Amqp\Consumer;
+
+/**
+ * Command to run consumer and execute consumer as a service
+ */
+class AMQPConsumerCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this->setName('m6web:rabbitmq:consumer')
+            ->setDescription('Run consumer as a command')
+            ->addArgument('consumer-name', InputArgument::REQUIRED, 'Consumer name')
+            ->addOption('count', 'c', InputOption::VALUE_REQUIRED, 'How many messages to consume before exit. 0 - do not exit', 0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var Consumer $consumer */
+        $consumer = $this->getContainer()->get(sprintf('m6_web_amqp.consumer.%s', $input->getArgument('consumer-name')));
+        $consumed = 0;
+        while ($input->getOption('count') == 0 || $consumed < $input->getOption('count')) {
+            $consumer->consume();
+
+            $consumed++;
+        }
+    }
+}

--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -140,6 +140,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('class')->defaultValue('%m6_web_amqp.consumer.class%')->end()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->scalarNode('callback')->info('service id that implements CallbackInterface and to be called when consume() message called w/o parameters')->end()
 
                             ->arrayNode('exchange_options')
                                 ->children()

--- a/src/AmqpBundle/Factory/AMQPFactory.php
+++ b/src/AmqpBundle/Factory/AMQPFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace M6Web\Bundle\AmqpBundle\Factory;
+
+/**
+ * Common code for both producer and consumer factories (channel, exchange declaration and binding)
+ */
+abstract class AMQPFactory
+{
+    /**
+     * Create and declare exchange
+     *
+     * @param string       $exchangeClass
+     * @param \AMQPChannel $channel
+     * @param array        $exchangeOptions
+     *
+     * @return \AMQPExchange
+     */
+    protected function createExchange($exchangeClass, $channel, array $exchangeOptions)
+    {
+        /** @var \AMQPExchange $exchange */
+        $exchange = new $exchangeClass($channel);
+        $exchange->setName($exchangeOptions['name']);
+        $exchange->setType($exchangeOptions['type']);
+        $exchange->setArguments($exchangeOptions['arguments']);
+        $exchange->setFlags(
+            ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
+            ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |
+            ($exchangeOptions['auto_delete'] ? AMQP_AUTODELETE : AMQP_NOPARAM)
+        );
+        $exchange->declareExchange();
+
+        return $exchange;
+    }
+}

--- a/src/AmqpBundle/Factory/ProducerFactory.php
+++ b/src/AmqpBundle/Factory/ProducerFactory.php
@@ -2,10 +2,12 @@
 
 namespace M6Web\Bundle\AmqpBundle\Factory;
 
+use M6Web\Bundle\AmqpBundle\Amqp\Producer;
+
 /**
  * ProducerFactory
  */
-class ProducerFactory
+class ProducerFactory extends AMQPFactory
 {
     /**
      * @var string
@@ -21,11 +23,6 @@ class ProducerFactory
      * @var string
      */
     protected $queueClass;
-
-    /**
-     * @var amqp channel
-     */
-    protected $channel;
 
     /**
      * __construct
@@ -64,11 +61,11 @@ class ProducerFactory
     /**
      * build the producer class
      *
-     * @param string $class           Provider class name
-     * @param string $connexion       AMQP connexion
-     * @param array  $exchangeOptions Exchange Options
-     * @param array  $queueOptions    Queue Options
-     * @param bool   $lazy            Specifies if it should connect
+     * @param string          $class           Provider class name
+     * @param \AMQPConnection $connexion       AMQP connexion
+     * @param array           $exchangeOptions Exchange Options
+     * @param array           $queueOptions    Queue Options
+     * @param bool            $lazy            Specifies if it should connect
      *
      * @return Producer
      */
@@ -87,20 +84,8 @@ class ProducerFactory
         }
 
         // Open a new channel
-        $channel = new $this->channelClass($connexion);
-
-        // Create and declare an exchange
-        /** @var \AMQPExchange $exchange */
-        $exchange = new $this->exchangeClass($channel);
-        $exchange->setName($exchangeOptions['name']);
-        $exchange->setType($exchangeOptions['type']);
-        $exchange->setArguments($exchangeOptions['arguments']);
-        $exchange->setFlags(
-            ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
-            ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |
-            ($exchangeOptions['auto_delete'] ? AMQP_AUTODELETE : AMQP_NOPARAM)
-        );
-        $exchange->declareExchange();
+        $channel  = new $this->channelClass($connexion);
+        $exchange = $this->createExchange($this->exchangeClass, $channel, $exchangeOptions);
 
         if (isset($queueOptions['name'])) {
             // create, declare queue, and bind it to exchange


### PR DESCRIPTION
`oldsound/rabbitmq-bundle` has a nice consumer support via command. All you need to do is implement specific callback for the consumer and schedule command execution via any scheduler.

From what I've seen you suggest using different library for implementing own commands. But in my case there are over 20 consumers. And I don't want to have a repeating command for each consumer.

This PR is an attempt to have generic command, like in oldsound bundle with backward-compatibility. It's still in progress but I decided to share it earlier to get feedback faster.

So welcome :)

P.S. I will rebase branch with meaningful commits when I'm done