### PR TITLE
Optionally exchange defined in consumer

### DIFF
--- a/src/AmqpBundle/Amqp/Consumer.php
+++ b/src/AmqpBundle/Amqp/Consumer.php
@@ -18,8 +18,6 @@ class Consumer extends AbstractAmqp
     protected $queueOptions = [];
 
     /**
-     * __construct
-     *
      * @param \AMQPQueue $queue        Amqp Queue
      * @param array      $queueOptions Queue options
      */
@@ -47,7 +45,7 @@ class Consumer extends AbstractAmqp
     /**
      * Acknowledge the receipt of a message.
      *
-     * @param string  $deliveryTag Delivery tag of last message to reject.
+     * @param string  $deliveryTag Delivery tag of last message to ack.
      * @param integer $flags       AMQP_MULTIPLE or AMQP_NOPARAM
      *
      * @return boolean
@@ -63,7 +61,7 @@ class Consumer extends AbstractAmqp
     /**
      * Mark a message as explicitly not acknowledged.
      *
-     * @param string  $deliveryTag Delivery tag of last message to reject.
+     * @param string  $deliveryTag Delivery tag of last message to nack.
      * @param integer $flags       AMQP_NOPARAM or AMQP_REQUEUE to requeue the message(s).
      *
      * @throws \AMQPChannelException If the channel is not open.

--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -152,9 +152,15 @@ class Configuration implements ConfigurationInterface
             ->end();
     }
 
+    /**
+     * Exchange options for both consumer and producer
+     *
+     * @return NodeDefinition
+     */
     private function exchangeOptions()
     {
         $builder = new NodeBuilder();
+
         return $builder
             ->arrayNode('exchange_options')
                 ->children()

--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace M6Web\Bundle\AmqpBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -67,36 +69,12 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('class')->defaultValue('%m6_web_amqp.producer.class%')->end()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->append($this->exchangeOptions())
                             ->arrayNode('queue_options')
                                 ->addDefaultsIfNotSet()
                                 ->children()
                                     // base info
                                     ->scalarNode('name')->end()
-
-                                    // flags
-                                    ->booleanNode('passive')->defaultFalse()->end()
-                                    ->booleanNode('durable')->defaultTrue()->end()
-                                    ->booleanNode('auto_delete')->defaultFalse()->end()
-
-                                    // args
-                                    ->arrayNode('arguments')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array())
-                                    ->normalizeKeys(false)
-                                    ->end()
-
-                                    // binding
-                                    ->arrayNode('routing_keys')
-                                    ->prototype('scalar')->end()
-                                    ->defaultValue(array())
-                                    ->end()
-                                ->end()
-                            ->end()
-                            ->arrayNode('exchange_options')
-                                ->children()
-                                    // base info
-                                    ->scalarNode('name')->isRequired()->end()
-                                    ->scalarNode('type')->isRequired()->end()
 
                                     // flags
                                     ->booleanNode('passive')->defaultFalse()->end()
@@ -112,12 +90,6 @@ class Configuration implements ConfigurationInterface
 
                                     // binding
                                     ->arrayNode('routing_keys')
-                                        ->prototype('scalar')->end()
-                                        ->defaultValue(array())
-                                    ->end()
-
-                                    // default message attributes
-                                    ->arrayNode('publish_attributes')
                                         ->prototype('scalar')->end()
                                         ->defaultValue(array())
                                     ->end()
@@ -140,13 +112,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('class')->defaultValue('%m6_web_amqp.consumer.class%')->end()
                             ->scalarNode('connection')->defaultValue('default')->end()
-
-                            ->arrayNode('exchange_options')
-                                ->children()
-                                    ->scalarNode('name')->isRequired()->end()
-                                ->end()
-                            ->end()
-
+                            ->append($this->exchangeOptions())
                             ->arrayNode('queue_options')
                                 ->children()
                                     // base
@@ -184,5 +150,44 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    private function exchangeOptions()
+    {
+        $builder = new NodeBuilder();
+        return $builder
+            ->arrayNode('exchange_options')
+                ->children()
+                    // base info
+                    ->scalarNode('name')->isRequired()->end()
+                    ->scalarNode('type')
+                        ->info('Set the type of the exchange. If exchange already exist - you can skip it. Otherwise behavior is unpredictable')
+                    ->end()
+
+                    // flags
+                    ->booleanNode('passive')->defaultFalse()->end()
+                    ->booleanNode('durable')->defaultTrue()->end()
+                    ->booleanNode('auto_delete')->defaultFalse()->end()
+
+                    // args
+                    ->arrayNode('arguments')
+                        ->prototype('scalar')->end()
+                        ->defaultValue(array())
+                        ->normalizeKeys(false)
+                    ->end()
+
+                    // binding
+                    ->arrayNode('routing_keys')
+                        ->prototype('scalar')->end()
+                        ->defaultValue(array())
+                    ->end()
+
+                    // default message attributes
+                    ->arrayNode('publish_attributes')
+                        ->prototype('scalar')->end()
+                        ->defaultValue(array())
+                    ->end()
+                ->end();
+            //last end is missed here intentionally because arrayNode doesn't have an actual parent
     }
 }

--- a/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
@@ -8,7 +8,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/src/AmqpBundle/Factory/AMQPFactory.php
+++ b/src/AmqpBundle/Factory/AMQPFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace M6Web\Bundle\AmqpBundle\Factory;
+
+/**
+ * Common code for both producer and consumer factories (channel, exchange declaration and binding)
+ */
+abstract class AMQPFactory
+{
+    /**
+     * Create and declare exchange
+     *
+     * @param string       $exchangeClass
+     * @param \AMQPChannel $channel
+     * @param array        $exchangeOptions
+     *
+     * @return \AMQPExchange
+     */
+    protected function createExchange($exchangeClass, $channel, array $exchangeOptions)
+    {
+        /** @var \AMQPExchange $exchange */
+        $exchange = new $exchangeClass($channel);
+        $exchange->setName($exchangeOptions['name']);
+        $exchange->setType($exchangeOptions['type']);
+        $exchange->setArguments($exchangeOptions['arguments']);
+        $exchange->setFlags(
+            ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
+            ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |
+            ($exchangeOptions['auto_delete'] ? AMQP_AUTODELETE : AMQP_NOPARAM)
+        );
+        $exchange->declareExchange();
+
+        return $exchange;
+    }
+}

--- a/src/AmqpBundle/Factory/ConsumerFactory.php
+++ b/src/AmqpBundle/Factory/ConsumerFactory.php
@@ -59,12 +59,12 @@ class ConsumerFactory extends AMQPFactory
     /**
      * build the consumer class
      *
-     * @param string                 $class           Consumer class name
-     * @param \AMQPConnection        $connexion       AMQP connexion
-     * @param array                  $exchangeOptions Exchange Options
-     * @param array                  $queueOptions    Queue Options
-     * @param bool                   $lazy            Specifies if it should connect
-     * @param array                  $qosOptions      Qos Options
+     * @param string          $class           Consumer class name
+     * @param \AMQPConnection $connexion       AMQP connexion
+     * @param array           $exchangeOptions Exchange Options
+     * @param array           $queueOptions    Queue Options
+     * @param bool            $lazy            Specifies if it should connect
+     * @param array           $qosOptions      Qos Options
      *
      * @return Consumer
      */

--- a/src/AmqpBundle/Factory/ConsumerFactory.php
+++ b/src/AmqpBundle/Factory/ConsumerFactory.php
@@ -2,10 +2,12 @@
 
 namespace M6Web\Bundle\AmqpBundle\Factory;
 
+use M6Web\Bundle\AmqpBundle\Amqp\Consumer;
+
 /**
  * ConsumerFactory
  */
-class ConsumerFactory
+class ConsumerFactory extends AMQPFactory
 {
     /**
      * @var string
@@ -18,19 +20,18 @@ class ConsumerFactory
     protected $queueClass;
 
     /**
-     * @var amqp channel
+     * @var string
      */
-    protected $channel;
+    protected $exchangeClass;
 
     /**
      * __construct
      *
-     * @param string $channelClass Channel class name
-     * @param string $queueClass   Queue class name
-     *
-     * @throws \InvalidArgumentException
+     * @param string $channelClass  Channel class name
+     * @param string $queueClass    Queue class name
+     * @param string $exchangeClass Exchange class name
      */
-    public function __construct($channelClass, $queueClass)
+    public function __construct($channelClass, $queueClass, $exchangeClass)
     {
         if (!class_exists($channelClass) || !is_a($channelClass, "AMQPChannel", true)) {
             throw new \InvalidArgumentException(
@@ -44,19 +45,26 @@ class ConsumerFactory
             );
         }
 
+        if (!class_exists($exchangeClass) || !is_a($exchangeClass, "AMQPExchange", true)) {
+            throw new \InvalidArgumentException(
+                sprintf("exchangeClass '%s' doesn't exist or not a AMQPExchange", $exchangeClass)
+            );
+        }
+
         $this->channelClass  = $channelClass;
         $this->queueClass = $queueClass;
+        $this->exchangeClass = $exchangeClass;
     }
 
     /**
      * build the consumer class
      *
-     * @param string $class           Consumer class name
-     * @param string $connexion       AMQP connexion
-     * @param array  $exchangeOptions Exchange Options
-     * @param array  $queueOptions    Queue Options
-     * @param bool   $lazy            Specifies if it should connect
-     * @param array  $qosOptions      Qos Options
+     * @param string                 $class           Consumer class name
+     * @param \AMQPConnection        $connexion       AMQP connexion
+     * @param array                  $exchangeOptions Exchange Options
+     * @param array                  $queueOptions    Queue Options
+     * @param bool                   $lazy            Specifies if it should connect
+     * @param array                  $qosOptions      Qos Options
      *
      * @return Consumer
      */
@@ -74,7 +82,7 @@ class ConsumerFactory
             }
         }
 
-        // Open a new channel
+        /** @var \AMQPChannel $channel */
         $channel = new $this->channelClass($connexion);
 
         if (isset($qosOptions['prefetch_size'])) {
@@ -84,7 +92,10 @@ class ConsumerFactory
             $channel->setPrefetchCount($qosOptions['prefetch_count']);
         }
 
-        // Create the queue
+        //ensure that exchange exists
+        $this->createExchange($this->exchangeClass, $channel, $exchangeOptions);
+
+        /** @var \AMQPQueue $queue */
         $queue = new $this->queueClass($channel);
         $queue->setName($queueOptions['name']);
         $queue->setArguments($queueOptions['arguments']);
@@ -103,9 +114,6 @@ class ConsumerFactory
             $queue->bind($exchangeOptions['name'], $routingKey);
         }
 
-        // Create the consumer
-        $consumer = new $class($queue, $queueOptions);
-
-        return $consumer;
+        return new $class($queue, $queueOptions);
     }
 }

--- a/src/AmqpBundle/Factory/ProducerFactory.php
+++ b/src/AmqpBundle/Factory/ProducerFactory.php
@@ -2,10 +2,12 @@
 
 namespace M6Web\Bundle\AmqpBundle\Factory;
 
+use M6Web\Bundle\AmqpBundle\Amqp\Producer;
+
 /**
  * ProducerFactory
  */
-class ProducerFactory
+class ProducerFactory extends AMQPFactory
 {
     /**
      * @var string
@@ -21,11 +23,6 @@ class ProducerFactory
      * @var string
      */
     protected $queueClass;
-
-    /**
-     * @var amqp channel
-     */
-    protected $channel;
 
     /**
      * __construct
@@ -64,11 +61,11 @@ class ProducerFactory
     /**
      * build the producer class
      *
-     * @param string $class           Provider class name
-     * @param string $connexion       AMQP connexion
-     * @param array  $exchangeOptions Exchange Options
-     * @param array  $queueOptions    Queue Options
-     * @param bool   $lazy            Specifies if it should connect
+     * @param string          $class           Provider class name
+     * @param \AMQPConnection $connexion       AMQP connexion
+     * @param array           $exchangeOptions Exchange Options
+     * @param array           $queueOptions    Queue Options
+     * @param bool            $lazy            Specifies if it should connect
      *
      * @return Producer
      */
@@ -87,20 +84,8 @@ class ProducerFactory
         }
 
         // Open a new channel
-        $channel = new $this->channelClass($connexion);
-
-        // Create and declare an exchange
-        /** @var \AMQPExchange $exchange */
-        $exchange = new $this->exchangeClass($channel);
-        $exchange->setName($exchangeOptions['name']);
-        $exchange->setType($exchangeOptions['type']);
-        $exchange->setArguments($exchangeOptions['arguments']);
-        $exchange->setFlags(
-            ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
-            ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |
-            ($exchangeOptions['auto_delete'] ? AMQP_AUTODELETE : AMQP_NOPARAM)
-        );
-        $exchange->declareExchange();
+        $channel  = new $this->channelClass($connexion);
+        $exchange = $this->createExchange($this->exchangeClass, $channel, $exchangeOptions);
 
         if (isset($queueOptions['name'])) {
             // create, declare queue, and bind it to exchange

--- a/src/AmqpBundle/Tests/Fixtures/queue-arguments-config.yml
+++ b/src/AmqpBundle/Tests/Fixtures/queue-arguments-config.yml
@@ -26,6 +26,7 @@ m6_web_amqp:
                 arguments:
                     x-message-ttl: 1000
     consumers:
+        #Assume that exchange is already defined
         consumer_1:
             connection: default
             exchange_options:
@@ -35,3 +36,12 @@ m6_web_amqp:
                 routing_keys: ['super_routing_key']
                 arguments:
                     x-dead-letter-exchange: 'exchange_2'
+        #Test how exchange is defined
+        consumer_2:
+            connection: default
+            exchange_options:
+                name: 'exchange_2'
+                type: direct
+                routing_keys: ['super_routing_key']
+            queue_options:
+                name: 'ha.queue_exchange_2'


### PR DESCRIPTION
This is an attempt to contribute changes made in #24 without actual command. This PR adds a functionality of consumer to define exchange. It allows to use consumer when exchange is not yet created. Tests updated.

Small comment updates included