### PR TITLE
Fix notice when exchange type not provided

### DIFF
--- a/src/AmqpBundle/Factory/AMQPFactory.php
+++ b/src/AmqpBundle/Factory/AMQPFactory.php
@@ -21,14 +21,18 @@ abstract class AMQPFactory
         /** @var \AMQPExchange $exchange */
         $exchange = new $exchangeClass($channel);
         $exchange->setName($exchangeOptions['name']);
-        $exchange->setType($exchangeOptions['type']);
-        $exchange->setArguments($exchangeOptions['arguments']);
-        $exchange->setFlags(
-            ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
-            ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |
-            ($exchangeOptions['auto_delete'] ? AMQP_AUTODELETE : AMQP_NOPARAM)
-        );
-        $exchange->declareExchange();
+
+        // If the type is not specified, the exchange must exist
+        if (isset($exchangeOptions['type'])) {
+            $exchange->setType($exchangeOptions['type']);
+            $exchange->setArguments($exchangeOptions['arguments']);
+            $exchange->setFlags(
+                ($exchangeOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |
+                ($exchangeOptions['durable'] ? AMQP_DURABLE : AMQP_NOPARAM) |
+                ($exchangeOptions['auto_delete'] ? AMQP_AUTODELETE : AMQP_NOPARAM)
+            );
+            $exchange->declareExchange();
+        }
 
         return $exchange;
     }


### PR DESCRIPTION
Since v1.8.0, the consumer factory makes a notice if the exchange type is not provided.

The exchange class accept the name only if the exchange is already created.

@mente 