### PR TITLE
Add scope prototype config option

### DIFF
--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -26,6 +26,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->booleanNode('event_dispatcher')->defaultTrue()->end()
+                ->booleanNode('prototype')->defaultFalse()->end()
             ->end();
 
         $this->addConnections($rootNode);

--- a/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
@@ -53,6 +53,10 @@ class M6WebAmqpExtension extends Extension
 
             $connectionDefinition->setArguments([['heartbeat' => $connection['heartbeat']]]);
 
+            if ($config['prototype']) {
+                $connectionDefinition->setScope('prototype');
+            }
+
             if (!$connection['lazy']) {
                 $connectionDefinition->addMethodCall('connect');
             }
@@ -101,6 +105,10 @@ class M6WebAmqpExtension extends Extension
             // Use a factory to build the producer
             $producerDefinition->setFactoryService('m6_web_amqp.producer_factory')
                                ->setFactoryMethod('get');
+
+            if ($config['prototype']) {
+                $producerDefinition->setScope('prototype');
+            }
 
             if ($lazy) {
                 if (!method_exists($producerDefinition, 'setLazy')) {
@@ -155,6 +163,10 @@ class M6WebAmqpExtension extends Extension
             // Use a factory to build the consumer
             $consumerDefinition->setFactoryService('m6_web_amqp.consumer_factory')
                                ->setFactoryMethod('get');
+
+            if ($config['prototype']) {
+                $consumerDefinition->setScope('prototype');
+            }
 
             if ($lazy) {
                 if (!method_exists($consumerDefinition, 'setLazy')) {

--- a/src/AmqpBundle/Tests/Fixtures/queue-arguments-config.yml
+++ b/src/AmqpBundle/Tests/Fixtures/queue-arguments-config.yml
@@ -1,4 +1,5 @@
 m6_web_amqp:
+    prototype: true
     connections:
         default:
             host:     'localhost'

--- a/src/AmqpBundle/Tests/Units/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/Tests/Units/DependencyInjection/M6WebAmqpExtension.php
@@ -41,6 +41,8 @@ class M6WebAmqpExtension extends test
         $this
             ->boolean($container->has('m6_web_amqp.producer.producer_2'))
                 ->isTrue()
+            ->string($container->getDefinition('m6_web_amqp.producer.producer_2')->getScope())
+                ->isEqualTo('prototype')
             ->array($queueOptions = $container->getDefinition('m6_web_amqp.producer.producer_2')->getArgument(3))
                 ->hasSize(6)
             ->string($queueOptions['name'])
@@ -63,6 +65,8 @@ class M6WebAmqpExtension extends test
         $this
             ->boolean($container->has('m6_web_amqp.consumer.consumer_1'))
                 ->isTrue()
+            ->string($container->getDefinition('m6_web_amqp.consumer.consumer_1')->getScope())
+                ->isEqualTo('prototype')
             ->array($queueOptions = $container->getDefinition('m6_web_amqp.consumer.consumer_1')->getArgument(3))
                 ->hasSize(7)
             ->string($queueOptions['name'])


### PR DESCRIPTION
Sometimes the prototype scope is useful for connexion and producer/consumer, to manage new connexion more easily.