### PR TITLE
Allow anonymous queue declaration

### DIFF
--- a/src/AmqpBundle/Factory/ConsumerFactory.php
+++ b/src/AmqpBundle/Factory/ConsumerFactory.php
@@ -97,7 +97,9 @@ class ConsumerFactory extends AMQPFactory
 
         /** @var \AMQPQueue $queue */
         $queue = new $this->queueClass($channel);
-        $queue->setName($queueOptions['name']);
+        if (!empty($queueOptions['name'])) {
+            $queue->setName($queueOptions['name']);
+        }
         $queue->setArguments($queueOptions['arguments']);
         $queue->setFlags(
             ($queueOptions['passive'] ? AMQP_PASSIVE : AMQP_NOPARAM) |


### PR DESCRIPTION
In some cases, it could be useful to use anonymous queues, for instance when we are connecting to a fanout exchange.

[Documentation states that](http://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.declare) : 
> The queue name MAY be empty, in which case the server MUST create a new queue with a unique generated name and return this to the client in the Declare-Ok method. 

An example is available in [RabbitMQ Tutoral 3](https://www.rabbitmq.com/tutorials/tutorial-three-php.html) ([link to receive_logs.php](https://github.com/rabbitmq/rabbitmq-tutorials/blob/546651dd80ff2226e1596f0c58065e4112cd076a/php/receive_logs.php#L12)).

Note that currently setting queue name in `config.yml` to an empty string or null will throw an exception.

I'm not sure if this makes sense in a producer point of view.