### PR TITLE
split timeout into read and write timeouts

### DIFF
--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -57,15 +57,36 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('class')->defaultValue('%m6_web_amqp.connection.class%')->end()
                             ->scalarNode('host')->defaultValue('localhost')->end()
                             ->scalarNode('port')->defaultValue(5672)->end()
-                            ->scalarNode('timeout')->defaultValue(10)->end()
+                            ->scalarNode('timeout')
+                                ->defaultValue(10)
+                                ->info('Read timeout for connection. Left for backwards compatibility. Use read_timeout instead')
+                            ->end()
+                            ->scalarNode('read_timeout')
+                                ->defaultNull()
+                                ->info('Read timeout for connection. If ommitted - use timeout value. Left for backwards compatibility')
+                            ->end()
+                            ->scalarNode('write_timeout')
+                                ->defaultValue(10)
+                                ->info('Write timeout for connection')
+                            ->end()
                             ->scalarNode('heartbeat')
                                 ->defaultValue(5)
-                                ->info('Send heartbeat every N seconds. RabbitMQ recommend to use timeout / 2. Supported from 1.6.0beta4 version of amqp extension')
+                                ->info('Send heartbeat every N seconds. RabbitMQ recommend to use read_timeout / 2. Supported from 1.6.0beta4 version of amqp extension')
                             ->end()
                             ->scalarNode('login')->defaultValue('guest')->end()
                             ->scalarNode('password')->defaultValue('guest')->end()
                             ->scalarNode('vhost')->defaultValue('/')->end()
                             ->booleanNode('lazy')->defaultFalse()->end()
+                        ->end()
+                        //backwards compatibility part to copy timeout value to read_timeout if read_timeout is not set
+                        ->validate()
+                            ->always(function($v) {
+                                if ($v['read_timeout'] === null) {
+                                    $v['read_timeout'] = $v['timeout'];
+                                }
+
+                                return $v;
+                            })
                         ->end()
                     ->end()
                 ->end()

--- a/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
@@ -50,12 +50,15 @@ class M6WebAmqpExtension extends Extension
             $connectionDefinition = new Definition($connection['class']);
             $connectionDefinition->addMethodCall('setHost ', [$connection['host']])
                                 ->addMethodCall('setPort', [$connection['port']])
-                                ->addMethodCall('setReadTimeout', [$connection['timeout']])
                                 ->addMethodCall('setLogin', [$connection['login']])
                                 ->addMethodCall('setPassword', [$connection['password']])
                                 ->addMethodCall('setVhost', [$connection['vhost']]);
 
-            $connectionDefinition->setArguments([['heartbeat' => $connection['heartbeat']]]);
+            $connectionDefinition->setArguments([[
+                'heartbeat' => $connection['heartbeat'],
+                'read_timeout' => $connection['read_timeout'],
+                'write_timeout' => $connection['write_timeout'],
+            ]]);
 
             if ($config['prototype']) {
                 $connectionDefinition->setShared(false);

--- a/src/AmqpBundle/Tests/Fixtures/queue-arguments-config.yml
+++ b/src/AmqpBundle/Tests/Fixtures/queue-arguments-config.yml
@@ -20,6 +20,26 @@ m6_web_amqp:
             vhost:    '/'
             lazy:     true
             heartbeat: 1
+        with_read_timeout_and_timeout:
+            host:     'localhost'
+            port:     5672
+            read_timeout:  100
+            write_timeout: 50
+            timeout: 3
+            login:    'guest'
+            password: 'guest'
+            vhost:    '/'
+            lazy:     true
+            heartbeat: 1
+        with_read_timeout_only:
+            host:     'localhost'
+            port:     5672
+            read_timeout:  100
+            login:    'guest'
+            password: 'guest'
+            vhost:    '/'
+            lazy:     true
+            heartbeat: 1
     producers:
         producer_1:
             connection: default

--- a/src/AmqpBundle/Tests/Units/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/Tests/Units/DependencyInjection/M6WebAmqpExtension.php
@@ -91,6 +91,23 @@ class M6WebAmqpExtension extends test
                 ->hasSize(1)
             ->integer($connectionArguments[0]['heartbeat'])
                 ->isEqualTo(1);
+        $this
+            ->boolean($container->has('m6_web_amqp.connection.with_read_timeout_and_timeout'))
+                ->isTrue()
+            ->array($connectionArguments = $container->getDefinition('m6_web_amqp.connection.with_read_timeout_and_timeout')->getArguments())
+                ->hasSize(1)
+            ->integer($connectionArguments[0]['read_timeout'])
+                ->isEqualTo(100)
+            ->integer($connectionArguments[0]['write_timeout'])
+                ->isEqualTo(50);
+
+        $this
+            ->boolean($container->has('m6_web_amqp.connection.with_read_timeout_only'))
+                ->isTrue()
+            ->array($connectionArguments = $container->getDefinition('m6_web_amqp.connection.with_read_timeout_only')->getArguments())
+                ->hasSize(1)
+            ->integer($connectionArguments[0]['read_timeout'])
+                ->isEqualTo(100);
     }
 
     public function testSandboxClasses()


### PR DESCRIPTION
Sometimes you need to have a different timeouts for reads and writes. As an example when you might need higher timeout for long processing consumers and small write timeout for failing fast producers

I have kept backwards compatibility. Documentation update is actually missing, should I?