### PR TITLE
psr4 autoload more specific as in other M6 bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name" : "m6web/amqp-bundle",
     "description" : "Bundle AMQP",
     "autoload" : {
-        "psr-4": { "M6Web\\Bundle\\": "src/" }
+        "psr-4": { "M6Web\\Bundle\\AmqpBundle\\": "src/" }
     },
     "config": {
         "bin-dir": "bin/"


### PR DESCRIPTION
Looking for a bug in my autoloader configuration I noticed that:
```
'M6Web\\Bundle\\StatsdBundle\\' => array($vendorDir . '/m6web/statsd-bundle/src'),
'M6Web\\Bundle\\' => array($vendorDir . '/m6web/amqp-bundle/src'),
```