### PR TITLE
Fix Twig template location for Symfony 4

### DIFF
--- a/src/AmqpBundle/Resources/config/data_collector.yml
+++ b/src/AmqpBundle/Resources/config/data_collector.yml
@@ -3,7 +3,7 @@ services:
         class: M6Web\Bundle\AmqpBundle\Amqp\DataCollector
         arguments: ['amqp']
         tags:
-            - { name: data_collector, template: 'M6WebAmqpBundle:Collector:amqp', id: 'amqp' }
+            - { name: data_collector, template: '@M6WebAmqpBundle/Collector/amqp.html.twig', id: 'amqp' }
             - { name: kernel.event_listener, event: amqp.command, method: onCommand }
 
 

--- a/src/AmqpBundle/Resources/config/data_collector.yml
+++ b/src/AmqpBundle/Resources/config/data_collector.yml
@@ -3,7 +3,7 @@ services:
         class: M6Web\Bundle\AmqpBundle\Amqp\DataCollector
         arguments: ['amqp']
         tags:
-            - { name: data_collector, template: '@M6WebAmqpBundle/Collector/amqp.html.twig', id: 'amqp' }
+            - { name: data_collector, template: '@M6WebAmqp/Collector/amqp.html.twig', id: 'amqp' }
             - { name: kernel.event_listener, event: amqp.command, method: onCommand }
 
 

--- a/src/AmqpBundle/Resources/views/Collector/amqp.html.twig
+++ b/src/AmqpBundle/Resources/views/Collector/amqp.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -7,7 +7,7 @@
     {% set text %}
         {{ collector.commands | length }} commands (avg : {{ collector.avgexecutiontime|number_format(4) }} - total : {{ collector.totalexecutiontime|number_format(4) }})
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': true } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
The current version of this bundle crash the Web Profiler with Symfony 4.x.

I can run nicely the bundle with the changes submited in this pull request. But I don't know the compatibility status with the previous version of Symfony.