### PR TITLE
feat: drop symfony 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.1' ]
-        symfony-version: ['^3.4', '^4.4', '^5.0']
+        symfony-version: ['^4.4', '^5.0']
       fail-fast: false
     steps:
       - uses: actions/checkout@master

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
     "require" : {
         "php": ">=7.4",
         "ext-amqp": "*",
-        "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0",
-        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0",
-        "symfony/yaml": "^3.4 || ^4.3 || ^5.0",
-        "twig/twig": "^1.31 || ^2.0 || ^3.0"
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/yaml": "^4.4 || ^5.0",
+        "twig/twig": "^2.13 || ^3.0"
     },
     "require-dev" : {
         "atoum/atoum": "~4.0",

--- a/src/AmqpBundle/Amqp/AbstractAmqp.php
+++ b/src/AmqpBundle/Amqp/AbstractAmqp.php
@@ -16,10 +16,8 @@ abstract class AbstractAmqp
 
     /**
      * Class of the event notifier.
-     *
-     * @var string
      */
-    protected $eventClass = null;
+    protected ?string $eventClass = null;
 
     /**
      * Notify an event to the event dispatcher.
@@ -27,9 +25,9 @@ abstract class AbstractAmqp
      * @param string $command   The command name
      * @param array  $arguments Args of the command
      * @param mixed  $return    Return value of the command
-     * @param int    $time      Exec time
+     * @param int $time      Exec time
      */
-    protected function notifyEvent($command, $arguments, $return, $time = 0)
+    protected function notifyEvent(string $command, array $arguments, $return, int $time = 0)
     {
         if ($this->eventDispatcher) {
             $event = new $this->eventClass();
@@ -51,7 +49,7 @@ abstract class AbstractAmqp
      *
      * @return mixed
      */
-    protected function call($object, $name, array $arguments = [])
+    protected function call($object, string $name, array $arguments = [])
     {
         $start = microtime(true);
 
@@ -70,7 +68,7 @@ abstract class AbstractAmqp
      *
      * @throws \Exception
      */
-    public function setEventDispatcher($eventDispatcher, $eventClass)
+    public function setEventDispatcher($eventDispatcher, string $eventClass)
     {
         if (!is_object($eventDispatcher) || !method_exists($eventDispatcher, 'dispatch')) {
             throw new Exception('The EventDispatcher must be an object and implement a dispatch method');

--- a/src/AmqpBundle/Amqp/AbstractAmqp.php
+++ b/src/AmqpBundle/Amqp/AbstractAmqp.php
@@ -23,9 +23,9 @@ abstract class AbstractAmqp
      * @param string $command   The command name
      * @param array  $arguments Args of the command
      * @param mixed  $return    Return value of the command
-     * @param int $time      Exec time
+     * @param float $time      Exec time
      */
-    protected function notifyEvent(string $command, array $arguments, $return, int $time = 0)
+    protected function notifyEvent(string $command, array $arguments, $return, float $time = 0)
     {
         if ($this->eventDispatcher) {
             $event = new $this->eventClass();

--- a/src/AmqpBundle/Amqp/AbstractAmqp.php
+++ b/src/AmqpBundle/Amqp/AbstractAmqp.php
@@ -2,20 +2,18 @@
 
 namespace M6Web\Bundle\AmqpBundle\Amqp;
 
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
 /**
  * Abstract AMQP.
  */
 abstract class AbstractAmqp
 {
-    /**
-     * Event dispatcher.
-     *
-     * @var object
-     */
-    protected $eventDispatcher = null;
+    protected ?EventDispatcherInterface $eventDispatcher = null;
 
     /**
      * Class of the event notifier.
+     * @var ?class-string $eventClass
      */
     protected ?string $eventClass = null;
 
@@ -36,7 +34,7 @@ abstract class AbstractAmqp
                   ->setReturn($return)
                   ->setExecutionTime($time);
 
-            $this->eventDispatcher->dispatch('amqp.command', $event);
+            $this->eventDispatcher->dispatch($event, 'amqp.command');
         }
     }
 
@@ -49,7 +47,7 @@ abstract class AbstractAmqp
      *
      * @return mixed
      */
-    protected function call($object, string $name, array $arguments = [])
+    protected function call(object $object, string $name, array $arguments = [])
     {
         $start = microtime(true);
 
@@ -63,17 +61,13 @@ abstract class AbstractAmqp
     /**
      * Set an event dispatcher to notify amqp command.
      *
-     * @param object $eventDispatcher The eventDispatcher object, which implement the notify method
-     * @param string $eventClass      The event class used to create an event and send it to the event dispatcher
+     * @param EventDispatcherInterface $eventDispatcher The eventDispatcher object, which implement the notify method
+     * @param string                   $eventClass      The event class used to create an event and send it to the event dispatcher
      *
      * @throws \Exception
      */
-    public function setEventDispatcher($eventDispatcher, string $eventClass)
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher, string $eventClass)
     {
-        if (!is_object($eventDispatcher) || !method_exists($eventDispatcher, 'dispatch')) {
-            throw new Exception('The EventDispatcher must be an object and implement a dispatch method');
-        }
-
         $class = new \ReflectionClass($eventClass);
         if (!$class->implementsInterface('\M6Web\Bundle\AmqpBundle\Event\DispatcherInterface')) {
             throw new Exception('The Event class : '.$eventClass.' must implement DispatcherInterface');

--- a/src/AmqpBundle/Amqp/Consumer.php
+++ b/src/AmqpBundle/Amqp/Consumer.php
@@ -34,15 +34,16 @@ class Consumer extends AbstractAmqp
     public function getMessage(int $flags = AMQP_AUTOACK): ?\AMQPEnvelope
     {
         $envelope = $this->call($this->queue, 'get', [$flags]);
+        $envelope = $envelope === false ? null : $envelope;
 
         if ($this->eventDispatcher) {
             $preRetrieveEvent = new PreRetrieveEvent($envelope);
-            $this->eventDispatcher->dispatch( $preRetrieveEvent, PreRetrieveEvent::NAME);
+            $this->eventDispatcher->dispatch($preRetrieveEvent, PreRetrieveEvent::NAME);
 
             return $preRetrieveEvent->getEnvelope();
         }
 
-        return $envelope === false ? null : $envelope;
+        return $envelope;
     }
 
     /**

--- a/src/AmqpBundle/Amqp/Consumer.php
+++ b/src/AmqpBundle/Amqp/Consumer.php
@@ -37,7 +37,7 @@ class Consumer extends AbstractAmqp
 
         if ($this->eventDispatcher) {
             $preRetrieveEvent = new PreRetrieveEvent($envelope);
-            $this->eventDispatcher->dispatch(PreRetrieveEvent::NAME, $preRetrieveEvent);
+            $this->eventDispatcher->dispatch( $preRetrieveEvent, PreRetrieveEvent::NAME);
 
             return $preRetrieveEvent->getEnvelope();
         }
@@ -59,7 +59,7 @@ class Consumer extends AbstractAmqp
         if ($this->eventDispatcher) {
             $ackEvent = new AckEvent($deliveryTag, $flags);
 
-            $this->eventDispatcher->dispatch(AckEvent::NAME, $ackEvent);
+            $this->eventDispatcher->dispatch($ackEvent,AckEvent::NAME);
         }
 
         return $this->call($this->queue, 'ack', [$deliveryTag, $flags]);
@@ -79,7 +79,7 @@ class Consumer extends AbstractAmqp
         if ($this->eventDispatcher) {
             $nackEvent = new NackEvent($deliveryTag, $flags);
 
-            $this->eventDispatcher->dispatch(NackEvent::NAME, $nackEvent);
+            $this->eventDispatcher->dispatch($nackEvent, NackEvent::NAME);
         }
 
         return $this->call($this->queue, 'nack', [$deliveryTag, $flags]);
@@ -96,7 +96,7 @@ class Consumer extends AbstractAmqp
         if ($this->eventDispatcher) {
             $purgeEvent = new PurgeEvent($this->queue);
 
-            $this->eventDispatcher->dispatch(PurgeEvent::NAME, $purgeEvent);
+            $this->eventDispatcher->dispatch($purgeEvent, PurgeEvent::NAME);
         }
 
         return $this->call($this->queue, 'purge');

--- a/src/AmqpBundle/Amqp/DataCollector.php
+++ b/src/AmqpBundle/Amqp/DataCollector.php
@@ -2,6 +2,7 @@
 
 namespace M6Web\Bundle\AmqpBundle\Amqp;
 
+use M6Web\Bundle\AmqpBundle\Event\DispatcherInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector as SymfonyDataCollector;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,11 +12,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class DataCollector extends SymfonyDataCollector
 {
-    /**
-     * @param string $name
-     *
-     * Construct the data collector
-     */
     public function __construct(string $name)
     {
         $this->data['name'] = $name;
@@ -25,20 +21,20 @@ class DataCollector extends SymfonyDataCollector
     /**
      * Collect the data.
      *
-     * @param Request    $request   The request object
-     * @param Response   $response  The response object
-     * @param \Exception $exception An exception
+     * @param Request $request The request object
+     * @param Response $response The response object
+     * @param \Throwable|null $exception An exception
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null)
     {
     }
 
     /**
      * Listen for command event.
      *
-     * @param object $event The event object
+     * @param DispatcherInterface $event The event object
      */
-    public function onCommand($event)
+    public function onCommand(DispatcherInterface $event)
     {
         $this->data['commands'][] = array(
             'command' => $event->getCommand(),
@@ -59,8 +55,6 @@ class DataCollector extends SymfonyDataCollector
 
     /**
      * Return the name of the collector.
-     *
-     * @return string data collector name
      */
     public function getName(): string
     {
@@ -69,8 +63,6 @@ class DataCollector extends SymfonyDataCollector
 
     /**
      * Return total command execution time.
-     *
-     * @return float
      */
     public function getTotalExecutionTime(): float
     {

--- a/src/AmqpBundle/Amqp/Locator.php
+++ b/src/AmqpBundle/Amqp/Locator.php
@@ -5,10 +5,10 @@ namespace M6Web\Bundle\AmqpBundle\Amqp;
 class Locator
 {
     /**  @var Consumer[] */
-    protected $consumers = [];
+    protected array $consumers = [];
 
     /** @var Producer[] */
-    protected $producers = [];
+    protected array $producers = [];
 
     public function getConsumer(string $id): Consumer
     {

--- a/src/AmqpBundle/Amqp/Producer.php
+++ b/src/AmqpBundle/Amqp/Producer.php
@@ -9,15 +9,9 @@ use M6Web\Bundle\AmqpBundle\Event\PrePublishEvent;
  */
 class Producer extends AbstractAmqp
 {
-    /**
-     * @var \AMQPExchange
-     */
-    protected $exchange = null;
+    protected \AMQPExchange $exchange;
 
-    /**
-     * @var array
-     */
-    protected $exchangeOptions = [];
+    protected array $exchangeOptions = [];
 
     /**
      * Constructor.
@@ -45,7 +39,7 @@ class Producer extends AbstractAmqp
      * @throws \AMQPChannelException    if the channel is not open
      * @throws \AMQPConnectionException if the connection to the broker was lost
      */
-    public function publishMessage($message, $flags = AMQP_NOPARAM, array $attributes = [], array $routingKeys = [])
+    public function publishMessage(string $message, int $flags = AMQP_NOPARAM, array $attributes = [], array $routingKeys = []): bool
     {
         // Merge attributes
         $attributes = empty($attributes) ? $this->exchangeOptions['publish_attributes'] :
@@ -81,40 +75,24 @@ class Producer extends AbstractAmqp
         return (bool) $success;
     }
 
-    /**
-     * @return \AMQPExchange
-     */
-    public function getExchange()
+    public function getExchange(): \AMQPExchange
     {
         return $this->exchange;
     }
 
-    /**
-     * @param \AMQPExchange $exchange
-     *
-     * @return \M6Web\Bundle\AmqpBundle\Amqp\Consumer
-     */
-    public function setExchange(\AMQPExchange $exchange)
+    public function setExchange(\AMQPExchange $exchange): self
     {
         $this->exchange = $exchange;
 
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getExchangeOptions()
+    public function getExchangeOptions(): array
     {
         return $this->exchangeOptions;
     }
 
-    /**
-     * @param array $exchangeOptions
-     *
-     * @return \M6Web\Bundle\AmqpBundle\Amqp\Consumer
-     */
-    public function setExchangeOptions(array $exchangeOptions)
+    public function setExchangeOptions(array $exchangeOptions): self
     {
         $this->exchangeOptions = $exchangeOptions;
 

--- a/src/AmqpBundle/Amqp/Producer.php
+++ b/src/AmqpBundle/Amqp/Producer.php
@@ -50,7 +50,7 @@ class Producer extends AbstractAmqp
 
         if ($this->eventDispatcher) {
             $prePublishEvent = new PrePublishEvent($message, $routingKeys, $flags, $attributes);
-            $this->eventDispatcher->dispatch(PrePublishEvent::NAME, $prePublishEvent);
+            $this->eventDispatcher->dispatch($prePublishEvent,PrePublishEvent::NAME);
 
             if (!$prePublishEvent->canPublish()) {
                 return true;

--- a/src/AmqpBundle/DependencyInjection/Configuration.php
+++ b/src/AmqpBundle/DependencyInjection/Configuration.php
@@ -18,16 +18,10 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('m6_web_amqp');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // symfony < 4.2 support
-            $rootNode = $treeBuilder->root('m6_web_amqp');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/DependencyInjection/M6WebAmqpExtension.php
@@ -40,10 +40,6 @@ class M6WebAmqpExtension extends Extension
         $this->loadConsumers($container, $config);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
     protected function loadConnections(ContainerBuilder $container, array $config)
     {
         foreach ($config['connections'] as $key => $connection) {
@@ -72,10 +68,6 @@ class M6WebAmqpExtension extends Extension
         }
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
     protected function loadProducers(ContainerBuilder $container, array $config)
     {
         foreach ($config['producers'] as $key => $producer) {
@@ -121,10 +113,6 @@ class M6WebAmqpExtension extends Extension
         }
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
     protected function loadConsumers(ContainerBuilder $container, array $config)
     {
         foreach ($config['consumers'] as $key => $consumer) {
@@ -171,12 +159,7 @@ class M6WebAmqpExtension extends Extension
         }
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param bool             $enableEventDispatcher
-     * @param Definition       $definition
-     */
-    private function setEventDispatcher(ContainerBuilder $container, $enableEventDispatcher, Definition $definition)
+    private function setEventDispatcher(ContainerBuilder $container, bool $enableEventDispatcher, Definition $definition)
     {
         // Add the Event dispatcher & Command Event
         if ($enableEventDispatcher === true) {

--- a/src/AmqpBundle/Event/AckEvent.php
+++ b/src/AmqpBundle/Event/AckEvent.php
@@ -2,49 +2,31 @@
 
 namespace M6Web\Bundle\AmqpBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Acknowledged message event.
  */
-class AckEvent extends SymfonyEvent
+class AckEvent extends Event
 {
     const NAME = 'amqp.ack';
 
-    /**
-     * @var string
-     */
-    private $deliveryTag;
+    private string $deliveryTag;
 
-    /**
-     * @var int
-     */
-    private $flags;
+    private int $flags;
 
-    /**
-     * Constructor.
-     *
-     * @param string $deliveryTag
-     * @param int    $flags
-     */
-    public function __construct($deliveryTag, $flags)
+    public function __construct(string $deliveryTag, int $flags)
     {
         $this->deliveryTag = $deliveryTag;
         $this->flags = $flags;
     }
 
-    /**
-     * @return string
-     */
-    public function getDeliveryTag()
+    public function getDeliveryTag(): string
     {
         return $this->deliveryTag;
     }
 
-    /**
-     * @return int
-     */
-    public function getFlags()
+    public function getFlags(): int
     {
         return $this->flags;
     }

--- a/src/AmqpBundle/Event/Command.php
+++ b/src/AmqpBundle/Event/Command.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class Command extends Event implements DispatcherInterface
 {
-    protected int $executionTime = 0;
+    protected float $executionTime = 0.0;
     protected string $command;
     protected array $arguments;
 

--- a/src/AmqpBundle/Event/Command.php
+++ b/src/AmqpBundle/Event/Command.php
@@ -2,27 +2,16 @@
 
 namespace M6Web\Bundle\AmqpBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Command Event.
  */
-class Command extends SymfonyEvent implements DispatcherInterface
+class Command extends Event implements DispatcherInterface
 {
-    /**
-     * @var int
-     */
-    protected $executionTime = 0;
-
-    /**
-     * @var string
-     */
-    protected $command;
-
-    /**
-     * @var array
-     */
-    protected $arguments;
+    protected int $executionTime = 0;
+    protected string $command;
+    protected array $arguments;
 
     /**
      * @var mixed
@@ -30,13 +19,9 @@ class Command extends SymfonyEvent implements DispatcherInterface
     protected $return;
 
     /**
-     * Set the command associated with this event.
-     *
-     * @param string $command The command
-     *
-     * @return $this
+     * @inheritDoc
      */
-    public function setCommand($command)
+    public function setCommand(string $command): self
     {
         $this->command = $command;
 
@@ -45,22 +30,16 @@ class Command extends SymfonyEvent implements DispatcherInterface
 
     /**
      * Get the command associated with this event.
-     *
-     * @return string the command
      */
-    public function getCommand()
+    public function getCommand(): string
     {
         return $this->command;
     }
 
     /**
-     * set the arguments.
-     *
-     * @param array $v argus
-     *
-     * @return $this
+     * Set the arguments.
      */
-    public function setArguments($v)
+    public function setArguments(array $v): self
     {
         $this->arguments = $v;
 
@@ -68,11 +47,9 @@ class Command extends SymfonyEvent implements DispatcherInterface
     }
 
     /**
-     * get the arguments.
-     *
-     * @return array
+     * Get the arguments.
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }
@@ -81,10 +58,8 @@ class Command extends SymfonyEvent implements DispatcherInterface
      * set the return value.
      *
      * @param mixed $v value
-     *
-     * @return $this
      */
-    public function setReturn($v)
+    public function setReturn($v): self
     {
         $this->return = $v;
 
@@ -102,13 +77,9 @@ class Command extends SymfonyEvent implements DispatcherInterface
     }
 
     /**
-     * set the exec time.
-     *
-     * @param float $v temps
-     *
-     * @return $this
+     * @inheritDoc
      */
-    public function setExecutionTime($v)
+    public function setExecutionTime(float $v): self
     {
         $this->executionTime = $v;
 
@@ -120,7 +91,7 @@ class Command extends SymfonyEvent implements DispatcherInterface
      *
      * @return float $v temps
      */
-    public function getExecutionTime()
+    public function getExecutionTime(): float
     {
         return $this->executionTime;
     }
@@ -128,10 +99,8 @@ class Command extends SymfonyEvent implements DispatcherInterface
     /**
      * Alias of getExecutionTime for the statsd bundle
      * In ms.
-     *
-     * @return float
      */
-    public function getTiming()
+    public function getTiming(): float
     {
         return $this->getExecutionTime() * 1000;
     }

--- a/src/AmqpBundle/Event/DispatcherInterface.php
+++ b/src/AmqpBundle/Event/DispatcherInterface.php
@@ -12,21 +12,21 @@ interface DispatcherInterface
      *
      * @param string $command The sqs command
      */
-    public function setCommand($command);
+    public function setCommand(string $command);
 
     /**
      * set execution time.
      *
      * @param float $v temps
      */
-    public function setExecutionTime($v);
+    public function setExecutionTime(float $v);
 
     /**
      * set the arguments.
      *
      * @param array $v argus
      */
-    public function setArguments($v);
+    public function setArguments(array $v);
 
     /**
      * set the return value.

--- a/src/AmqpBundle/Event/NackEvent.php
+++ b/src/AmqpBundle/Event/NackEvent.php
@@ -2,49 +2,30 @@
 
 namespace M6Web\Bundle\AmqpBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Not acknowledged message event.
  */
-class NackEvent extends SymfonyEvent
+class NackEvent extends Event
 {
     const NAME = 'amqp.nack';
 
-    /**
-     * @var string
-     */
-    private $deliveryTag;
+    private string $deliveryTag;
+    private int $flags;
 
-    /**
-     * @var int
-     */
-    private $flags;
-
-    /**
-     * Constructor.
-     *
-     * @param string $deliveryTag
-     * @param int    $flags
-     */
-    public function __construct($deliveryTag, $flags)
+    public function __construct(string $deliveryTag, int $flags)
     {
         $this->deliveryTag = $deliveryTag;
         $this->flags = $flags;
     }
 
-    /**
-     * @return string
-     */
-    public function getDeliveryTag()
+    public function getDeliveryTag(): string
     {
         return $this->deliveryTag;
     }
 
-    /**
-     * @return int
-     */
-    public function getFlags()
+    public function getFlags(): int
     {
         return $this->flags;
     }

--- a/src/AmqpBundle/Event/PrePublishEvent.php
+++ b/src/AmqpBundle/Event/PrePublishEvent.php
@@ -2,49 +2,22 @@
 
 namespace M6Web\Bundle\AmqpBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * PrePublishEvent.
  */
-class PrePublishEvent extends SymfonyEvent
+class PrePublishEvent extends Event
 {
     const NAME = 'amqp.pre_publish';
 
-    /**
-     * @var string
-     */
-    private $message;
+    private string $message;
+    private array $routingKeys;
+    private int $flags;
+    private array $attributes;
+    private bool $canPublish;
 
-    /**
-     * @var array
-     */
-    private $routingKeys;
-
-    /**
-     * @var int
-     */
-    private $flags;
-
-    /**
-     * @var array
-     */
-    private $attributes;
-
-    /**
-     * @var bool
-     */
-    private $canPublish;
-
-    /**
-     * Constructor.
-     *
-     * @param string $message
-     * @param array  $routingKeys
-     * @param int    $flags
-     * @param array  $attributes
-     */
-    public function __construct($message, $routingKeys, $flags, $attributes)
+    public function __construct(string $message, array $routingKeys, int $flags, array $attributes)
     {
         $this->message = $message;
         $this->routingKeys = $routingKeys;
@@ -53,90 +26,57 @@ class PrePublishEvent extends SymfonyEvent
         $this->canPublish = true;
     }
 
-    /**
-     * @return bool
-     */
-    public function canPublish()
+    public function canPublish(): bool
     {
         return $this->canPublish;
     }
 
-    /**
-     * Allow publish.
-     */
     public function allowPublish()
     {
         $this->canPublish = true;
     }
 
-    /**
-     * Deny publish.
-     */
     public function denyPublish()
     {
         $this->canPublish = false;
     }
 
-    /**
-     * @return string
-     */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    /**
-     * @param string $message
-     */
-    public function setMessage($message)
+    public function setMessage(string $message)
     {
         $this->message = $message;
     }
 
-    /**
-     * @return array
-     */
-    public function getRoutingKeys()
+    public function getRoutingKeys(): array
     {
         return $this->routingKeys;
     }
 
-    /**
-     * @param array $routingKeys
-     */
-    public function setRoutingKeys($routingKeys)
+    public function setRoutingKeys(array $routingKeys)
     {
         $this->routingKeys = $routingKeys;
     }
 
-    /**
-     * @return int
-     */
-    public function getFlags()
+    public function getFlags(): int
     {
         return $this->flags;
     }
 
-    /**
-     * @param int $flags
-     */
-    public function setFlags($flags)
+    public function setFlags(int $flags)
     {
         $this->flags = $flags;
     }
 
-    /**
-     * @return array
-     */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
 
-    /**
-     * @param array $attributes
-     */
-    public function setAttributes($attributes)
+    public function setAttributes(array $attributes)
     {
         $this->attributes = $attributes;
     }

--- a/src/AmqpBundle/Event/PreRetrieveEvent.php
+++ b/src/AmqpBundle/Event/PreRetrieveEvent.php
@@ -3,42 +3,28 @@
 namespace M6Web\Bundle\AmqpBundle\Event;
 
 use AMQPEnvelope;
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Pre retrieve message event.
  */
-class PreRetrieveEvent extends SymfonyEvent
+class PreRetrieveEvent extends Event
 {
     const NAME = 'amqp.pre_retrieve';
 
-    /**
-     * @var AMQPEnvelope|bool
-     */
-    private $envelope;
+    private AMQPEnvelope $envelope;
 
-    /**
-     * Constructor.
-     *
-     * @param AMQPEnvelope|bool $envelope
-     */
-    public function __construct($envelope)
+    public function __construct(AMQPEnvelope $envelope)
     {
         $this->envelope = $envelope;
     }
 
-    /**
-     * @return AMQPEnvelope|bool
-     */
-    public function getEnvelope()
+    public function getEnvelope(): AMQPEnvelope
     {
         return $this->envelope;
     }
 
-    /**
-     * @param AMQPEnvelope|bool $envelope
-     */
-    public function setEnvelope($envelope)
+    public function setEnvelope(AMQPEnvelope $envelope)
     {
         $this->envelope = $envelope;
     }

--- a/src/AmqpBundle/Event/PreRetrieveEvent.php
+++ b/src/AmqpBundle/Event/PreRetrieveEvent.php
@@ -12,19 +12,19 @@ class PreRetrieveEvent extends Event
 {
     const NAME = 'amqp.pre_retrieve';
 
-    private AMQPEnvelope $envelope;
+    private ?AMQPEnvelope $envelope;
 
-    public function __construct(AMQPEnvelope $envelope)
+    public function __construct(?AMQPEnvelope $envelope)
     {
         $this->envelope = $envelope;
     }
 
-    public function getEnvelope(): AMQPEnvelope
+    public function getEnvelope(): ?AMQPEnvelope
     {
         return $this->envelope;
     }
 
-    public function setEnvelope(AMQPEnvelope $envelope)
+    public function setEnvelope(?AMQPEnvelope $envelope)
     {
         $this->envelope = $envelope;
     }

--- a/src/AmqpBundle/Event/PurgeEvent.php
+++ b/src/AmqpBundle/Event/PurgeEvent.php
@@ -2,34 +2,23 @@
 
 namespace M6Web\Bundle\AmqpBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Purge queue event.
  */
-class PurgeEvent extends SymfonyEvent
+class PurgeEvent extends Event
 {
     const NAME = 'amqp.purge';
 
-    /**
-     * @var \AMQPQueue
-     */
-    private $queue;
+    private \AMQPQueue $queue;
 
-    /**
-     * Constructor.
-     *
-     * @param \AMQPQueue $queue
-     */
-    public function __construct($queue)
+    public function __construct(\AMQPQueue $queue)
     {
         $this->queue = $queue;
     }
 
-    /**
-     * @return \AMQPQueue
-     */
-    public function getQueue()
+    public function getQueue(): \AMQPQueue
     {
         return $this->queue;
     }

--- a/src/AmqpBundle/Factory/AMQPFactory.php
+++ b/src/AmqpBundle/Factory/AMQPFactory.php
@@ -9,14 +9,8 @@ abstract class AMQPFactory
 {
     /**
      * Create and declare exchange.
-     *
-     * @param string       $exchangeClass
-     * @param \AMQPChannel $channel
-     * @param array        $exchangeOptions
-     *
-     * @return \AMQPExchange
      */
-    protected function createExchange($exchangeClass, $channel, array $exchangeOptions)
+    protected function createExchange(string $exchangeClass, \AMQPChannel $channel, array $exchangeOptions): \AMQPExchange
     {
         /** @var \AMQPExchange $exchange */
         $exchange = new $exchangeClass($channel);

--- a/src/AmqpBundle/Factory/ConsumerFactory.php
+++ b/src/AmqpBundle/Factory/ConsumerFactory.php
@@ -4,34 +4,20 @@ namespace M6Web\Bundle\AmqpBundle\Factory;
 
 use M6Web\Bundle\AmqpBundle\Amqp\Consumer;
 
-/**
- * ConsumerFactory.
- */
 class ConsumerFactory extends AMQPFactory
 {
-    /**
-     * @var string
-     */
-    protected $channelClass;
-
-    /**
-     * @var string
-     */
-    protected $queueClass;
-
-    /**
-     * @var string
-     */
-    protected $exchangeClass;
+    protected string $channelClass;
+    protected string $queueClass;
+    protected string $exchangeClass;
 
     /**
      * __construct.
      *
-     * @param string $channelClass  Channel class name
-     * @param string $queueClass    Queue class name
-     * @param string $exchangeClass Exchange class name
+     * @param class-string $channelClass  Channel class name
+     * @param class-string $queueClass    Queue class name
+     * @param class-string $exchangeClass Exchange class name
      */
-    public function __construct($channelClass, $queueClass, $exchangeClass)
+    public function __construct(string $channelClass, string $queueClass, string $exchangeClass)
     {
         if (!class_exists($channelClass) || !is_a($channelClass, 'AMQPChannel', true)) {
             throw new \InvalidArgumentException(
@@ -59,7 +45,7 @@ class ConsumerFactory extends AMQPFactory
     /**
      * build the consumer class.
      *
-     * @param string          $class           Consumer class name
+     * @param class-string    $class           Consumer class name
      * @param \AMQPConnection $connexion       AMQP connexion
      * @param array           $exchangeOptions Exchange Options
      * @param array           $queueOptions    Queue Options
@@ -68,7 +54,7 @@ class ConsumerFactory extends AMQPFactory
      *
      * @return Consumer
      */
-    public function get($class, $connexion, array $exchangeOptions, array $queueOptions, $lazy = false, array $qosOptions = [])
+    public function get(string $class, \AMQPConnection $connexion, array $exchangeOptions, array $queueOptions, bool $lazy = false, array $qosOptions = []): Consumer
     {
         if (!class_exists($class)) {
             throw new \InvalidArgumentException(

--- a/src/AmqpBundle/Factory/ProducerFactory.php
+++ b/src/AmqpBundle/Factory/ProducerFactory.php
@@ -4,36 +4,22 @@ namespace M6Web\Bundle\AmqpBundle\Factory;
 
 use M6Web\Bundle\AmqpBundle\Amqp\Producer;
 
-/**
- * ProducerFactory.
- */
 class ProducerFactory extends AMQPFactory
 {
-    /**
-     * @var string
-     */
-    protected $channelClass;
-
-    /**
-     * @var string
-     */
-    protected $exchangeClass;
-
-    /**
-     * @var string
-     */
-    protected $queueClass;
+    protected string $channelClass;
+    protected string $exchangeClass;
+    protected string $queueClass;
 
     /**
      * __construct.
      *
-     * @param string $channelClass  Channel class name
-     * @param string $exchangeClass Exchange class name
-     * @param string $queueClass    Queue class name
+     * @param class-string $channelClass  Channel class name
+     * @param class-string $exchangeClass Exchange class name
+     * @param class-string $queueClass    Queue class name
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($channelClass, $exchangeClass, $queueClass)
+    public function __construct(string $channelClass, string $exchangeClass, string $queueClass)
     {
         if (!class_exists($channelClass) || !is_a($channelClass, 'AMQPChannel', true)) {
             throw new \InvalidArgumentException(
@@ -61,7 +47,7 @@ class ProducerFactory extends AMQPFactory
     /**
      * build the producer class.
      *
-     * @param string          $class           Provider class name
+     * @param class-string     $class           Provider class name
      * @param \AMQPConnection $connexion       AMQP connexion
      * @param array           $exchangeOptions Exchange Options
      * @param array           $queueOptions    Queue Options
@@ -69,7 +55,7 @@ class ProducerFactory extends AMQPFactory
      *
      * @return Producer
      */
-    public function get($class, $connexion, array $exchangeOptions, array $queueOptions, $lazy = false)
+    public function get(string $class, \AMQPConnection $connexion, array $exchangeOptions, array $queueOptions, bool $lazy = false): Producer
     {
         if (!class_exists($class)) {
             throw new \InvalidArgumentException(
@@ -108,8 +94,6 @@ class ProducerFactory extends AMQPFactory
         }
 
         // Create the producer
-        $producer = new $class($exchange, $exchangeOptions);
-
-        return $producer;
+        return new $class($exchange, $exchangeOptions);
     }
 }

--- a/src/AmqpBundle/Tests/Units/Amqp/Consumer.php
+++ b/src/AmqpBundle/Tests/Units/Amqp/Consumer.php
@@ -276,7 +276,7 @@ class Consumer extends atoum
                 ->and($queue = new NullQueue($channel))
                 ->and($consumer = new Base($queue, []))
             ->then
-                ->boolean($consumer->getMessage())->isFalse()
+                ->variable($consumer->getMessage())->isNull()
                 ->integer($consumer->getCurrentMessageCount())->isEqualTo(0)
         ;
 

--- a/src/AmqpBundle/Tests/Units/DependencyInjection/M6WebAmqpExtension.php
+++ b/src/AmqpBundle/Tests/Units/DependencyInjection/M6WebAmqpExtension.php
@@ -5,8 +5,6 @@ namespace M6Web\Bundle\AmqpBundle\Tests\Units\DependencyInjection;
 use M6Web\Bundle\AmqpBundle\DependencyInjection\M6WebAmqpExtension as Base;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Yaml\Parser;
 use atoum;
 
@@ -15,10 +13,7 @@ use atoum;
  */
 class M6WebAmqpExtension extends atoum
 {
-    /**
-     * @return ContainerBuilder
-     */
-    protected function getContainerForConfiguration(string $fixtureName)
+    protected function getContainerForConfiguration(string $fixtureName): ContainerBuilder
     {
         $extension = new Base();
 

--- a/src/AmqpBundle/Tests/Units/Factory/ConsumerFactory.php
+++ b/src/AmqpBundle/Tests/Units/Factory/ConsumerFactory.php
@@ -91,7 +91,7 @@ class ConsumerFactory extends atoum
                 'prefetch_count' => 0,
             ])
             ->and($factory = new Base($channelClass, $queueClass, $exchangeClass))
-                ->object($factory->get($consumerClass, $connexion, $exchangeOptions, $queueOptions, $qosOptions))
+                ->object($factory->get($consumerClass, $connexion, $exchangeOptions, $queueOptions, false, $qosOptions))
                     ->isInstanceOf($consumerClass);
     }
 }

--- a/src/AmqpBundle/Tests/Units/Factory/Mock/MockAMQPChannel.php
+++ b/src/AmqpBundle/Tests/Units/Factory/Mock/MockAMQPChannel.php
@@ -14,4 +14,12 @@ class MockAMQPChannel extends \AMQPChannel
     public function qos($prefetchSize, $prefetchCount, $global = NULL)
     {
     }
+
+    public function setPrefetchSize($count){
+
+    }
+
+    public function setPrefetchCount($count){
+
+    }
 }


### PR DESCRIPTION
- Drop Symfony 3.2 compatibility. So I removed all deprecated alerts (event dispatcher) and removed the SF3 compatibility code.
- I also add PHP types, as a first step before dropping php 7.4 support. 

This PR will be released as a new major version.